### PR TITLE
Ignore creation on rpsec preset test

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ require('telescope-alternate').setup({
       { 'app/models/(.*).rb', { { 'db/helpers/**/*[1:pluralize]*.rb', 'Helper' } } },
       { 'app/**/*.rb', { { 'spec/[1].rb', 'Test' } } }, -- Alternate between file and test
     },
-    presets = { 'rails', 'nestjs' }, -- Telescope pre-defined mapping presets
+    presets = { 'rails', 'rspec', 'nestjs' }, -- Telescope pre-defined mapping presets
     transformers = { -- custom transformers
       change_to_uppercase = function(w) return my_uppercase_method(w) end
     }

--- a/lua/telescope-alternate/presets.lua
+++ b/lua/telescope-alternate/presets.lua
@@ -22,13 +22,9 @@ M.rails = {
 
 M.rspec = {
   { 'app/(.*).rb', { { 'spec/[1]_spec.rb', 'Test' } } },
-  { 'spec/(.*)_spec.rb', { { 'app/[1].rb', 'Original' } } },
-  { 'app/controllers/(.*)_controller.rb', {
-    { 'spec/requests/[1]_spec.rb', 'Request Test' }
-  } },
-  { 'spec/requests/(.*)_spec.rb', {
-    { 'app/controllers/[1]_controller.rb', 'Original' },
-  } },
+  { 'spec/(.*)_spec.rb', { { 'app/[1].rb', 'Original', true } } },
+  { 'app/controllers/(.*)_controller.rb', { { 'spec/requests/[1]_spec.rb', 'Request Test' } } },
+  { 'spec/requests/(.*)_spec.rb', { { 'app/controllers/[1]_controller.rb', 'Original', true }, } },
 }
 
 M.nestjs = {


### PR DESCRIPTION
This fixes the issue that we were running into earlier with the option to create a new original `app/requests/...` file by ignoring creation going from Test back to Original file. I believe this is a better user experience as this will automatically jump to the original file. Please let me know what you think!