### PR TITLE
#9 - fix normalizing paths to exclude lua pattern from substitution

### DIFF
--- a/lua/telescope-alternate/utils.lua
+++ b/lua/telescope-alternate/utils.lua
@@ -76,7 +76,11 @@ end
 function M.normalize_path(text)
   local s = text
 
-  s = string.gsub(s, '%-', '%%-')
+  -- Only target literal parts of the path (i.e exclude lua patterns)
+  -- This assumes that in the literal part of the path the `-` will be preceeded
+  -- by only alphanumeric characters. It also assumes that lua patters will only 
+  -- ever have an alpha-numeric char preceeding the `-` special character.
+  s = string.gsub(s, "(%x)%-", "%1%%-")
 
   return s
 end


### PR DESCRIPTION
Part of #9.

Fixes the substitution when normalising paths to exclude substitution `-` when used as a Lua special char.

The comment explains the caveats about the assumptions this makes. I don't know enough Lua or Lua pattern to write a fully robust fix, but this works for now and hopefully the comment helps to avoid future regressions.

If you have an idea for a better pattern, let me know 👍.

---

This change will allow the following path to be valid and work:

```
pattern = "(.-)([app|addon]+)/controllers/(.*/?)(.*).[jt]s$",
```

Prior to the fix, this would not work because the `(.-)` part was getting normalised to `(.%-)`, meaning that the `-` char was escaped.