### PR TITLE
Multilingual error check

### DIFF
--- a/lua/telescope-alternate/utils.lua
+++ b/lua/telescope-alternate/utils.lua
@@ -36,7 +36,7 @@ end
 function M.capture(path)
   local s = vim.fn.system("find " .. path)
 
-  if string.match(s, 'no matches found:') then
+  if vim.v.shell_error ~= 0 then
     return {}
   end
 
@@ -78,7 +78,7 @@ function M.normalize_path(text)
 
   -- Only target literal parts of the path (i.e exclude lua patterns)
   -- This assumes that in the literal part of the path the `-` will be preceeded
-  -- by only alphanumeric characters. It also assumes that lua patters will only 
+  -- by only alphanumeric characters. It also assumes that lua patters will only
   -- ever have an alpha-numeric char preceeding the `-` special character.
   s = string.gsub(s, "(%x)%-", "%1%%-")
 


### PR DESCRIPTION
The find error check only works if the system is in English. This PR replaces the output check with a flag set if a system call fails, making it work on systems other than English.