### PR TITLE
Support order for targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ require('telescope-alternate').setup({
     mappings = {
       { 'app/services/(.*)_services/(.*).rb', { -- alternate from services to contracts / models
         { 'app/contracts/[1]_contracts/[2].rb', 'Contract' }, -- Adding label to switch
-        { 'app/models/**/*[1].rb', 'Model', true }, -- Ignore create entry (with true)
+        {
+          'app/models/**/*[1].rb',
+          'Model',
+          true, -- Ignore create entry (with true)
+          1 -- order is optional should be a number. Items with lower order will be shown before items with higher order
+        },
       } },
       { 'app/contracts/(.*)_contracts/(.*).rb', { { 'app/services/[1]_services/[2].rb', 'Service' } } }, -- from contracts to services
       -- Search anything on helper folder that contains pluralize version of model.
@@ -69,7 +74,12 @@ require('telescope').setup{
 -- You also can use the verbose way to mapping:
 mappings = {
   { pattern = 'app/services/(.*)_services/(.*).rb', targets = {
-      { template =  'app/contracts/[1]_contracts/[2].rb', label = 'Contract', enable_new = true } -- enable_new can be a function too.
+      {
+         template =  'app/contracts/[1]_contracts/[2].rb',
+         label = 'Contract',
+         enable_new = true, -- enable_new can be a function too.
+         order = 1 -- order is optional should be a number. Items with lower order will be shown before items with higher order
+      }
     }
   },
   { pattern = 'app/contracts/(.*)_contracts/(.*).rb', targets = {

--- a/lua/telescope-alternate/snacks.lua
+++ b/lua/telescope-alternate/snacks.lua
@@ -1,0 +1,103 @@
+local Snacks = require("snacks")
+
+local M = {}
+local function removeCommonPrefix(nestedStrings)
+    if #nestedStrings == 0 then return nestedStrings end
+    if #nestedStrings == 1 then return nestedStrings end
+
+    -- Extract paths for processing
+    local paths = {}
+    for i, item in ipairs(nestedStrings) do
+        paths[i] = item.path
+    end
+
+    -- Find the shortest string length
+    local minLen = math.huge
+    for _, str in ipairs(paths) do
+        minLen = math.min(minLen, #str)
+    end
+
+    -- Find common prefix length
+    local prefixLen = 0
+    for i = 1, minLen do
+        local char = paths[1]:sub(i, i)
+        local isCommon = true
+        for _, str in ipairs(paths) do
+            if str:sub(i, i) ~= char then
+                isCommon = false
+                break
+            end
+        end
+        if isCommon then
+            prefixLen = i
+        else
+            break
+        end
+    end
+
+    -- Create new list with common prefix removed
+    local result = {}
+    for i, item in ipairs(nestedStrings) do
+        local newItem = { short_path = item.path:sub(prefixLen + 1), path=item.path, label = item.label, order = item.order }
+        table.insert(result, newItem)
+    end
+
+    return result
+end
+
+M.alternate = function()
+    local raw_files = require "telescope-alternate.finders".find_alternatve_files()
+    local files = removeCommonPrefix(raw_files)
+
+    Snacks.picker({
+        finder = function()
+            local items = {}
+            for i, item in ipairs(files) do
+                table.insert(items, {
+                    idx = i,
+                    order = item.order,
+                    file = item.path,
+                    text = item.short_path,
+                    label = item.label,
+                })
+            end
+            return items
+        end,
+        layout = {
+            layout = {
+                box = "horizontal",
+                width = 0.5,
+                height = 0.5,
+                {
+                    box = "vertical",
+                    border = "rounded",
+                    title = "Project files",
+                    { win = "input", height = 1,     border = "bottom" },
+                    { win = "list",  border = "none" },
+                },
+            },
+        },
+        format = function(item, _)
+            local file = item.file
+            local ret = {}
+            local a = Snacks.picker.util.align
+            local icon, icon_hl = Snacks.util.icon(file.ft, "directory")
+            ret[#ret + 1] = { a(item.label, 20) }
+            ret[#ret + 1] = { a(icon, 3), icon_hl }
+            ret[#ret + 1] = { " " }
+            ret[#ret + 1] = { a(item.text, 20) }
+
+            return ret
+        end,
+        confirm = function(picker, item)
+            picker:close()
+            vim.cmd.edit(item.file)
+            -- Snacks.picker.pick("files", {
+            --     files = { item.file },
+            -- })
+        end,
+    })
+end
+
+-- M.alternate()
+return M

--- a/lua/telescope-alternate/snacks.lua
+++ b/lua/telescope-alternate/snacks.lua
@@ -38,7 +38,13 @@ local function removeCommonPrefix(nestedStrings)
     -- Create new list with common prefix removed
     local result = {}
     for i, item in ipairs(nestedStrings) do
-        local newItem = { short_path = item.path:sub(prefixLen + 1), path=item.path, label = item.label, order = item.order }
+        local newItem = {
+            short_path = item.path:sub(prefixLen + 1),
+            path = item.path,
+            label = item.label,
+            order = item
+                .order
+        }
         table.insert(result, newItem)
     end
 
@@ -77,6 +83,31 @@ M.alternate = function()
                 },
             },
         },
+
+        -- win = {
+        --     -- input window
+        --     input = {
+        --         keys = {
+        --
+        --             ["<c-\\>"] = { "flash", mode = { "n", "i" } },
+        --             ["<c-s>"] = { "split", mode = { "n", "i" } },
+        --             ["<c-v>"] = { "vsplit", mode = { "n", "i" } },
+        --         }
+        --     }
+        -- },
+        --
+        -- list = {
+        --     -- input window
+        --     input = {
+        --         keys = {
+        --
+        --             ["<c-\\>"] = { "flash", mode = { "n", "i" } },
+        --             ["<c-s>"] = { "split", mode = { "n", "i" } },
+        --             ["<c-v>"] = { "vsplit", mode = { "n", "i" } },
+        --         }
+        --     }
+        -- },
+
         format = function(item, _)
             local file = item.file
             local ret = {}
@@ -89,13 +120,13 @@ M.alternate = function()
 
             return ret
         end,
-        confirm = function(picker, item)
-            picker:close()
-            vim.cmd.edit(item.file)
-            -- Snacks.picker.pick("files", {
-            --     files = { item.file },
-            -- })
-        end,
+        -- confirm = function(picker, item)
+        --     picker:close()
+        --     vim.cmd.edit(item.file)
+        --     -- Snacks.picker.pick("files", {
+        --     --     files = { item.file },
+        --     -- })
+        -- end,
     })
 end
 


### PR DESCRIPTION
When showing alternatives for a file I prefer some more frequent used ones to be shown first. Using this PR the config can be done in the following ways:

```lua
{
    pattern = "(.*)/models/(.*).php",
    targets = {
        { template = "[1]/models/[2].php",                      label="Model",        enable_new = true , order=1 },
        { template = "[1]/controllers/[2:pluralize].php",       label="Controller",   enable_new = true , order=2},
        { template = "[1]/models/[2:lower]/*fields.yaml",       label="Fields",       enable_new = true , order=3},
        { template = "[1]/models/[2:lower]/*columns.yaml",      label="Columns",      enable_new = true , order=4},
        { template = "[1]/models/[2:lower]/*.*",                label="Model-F",      enable_new = true , order=5},
        { template = "[1]/controllers/[2:pluralize,lower]/*.*", label="Controller-F", enable_new = true , order=6},
    },
},


```

or non-verbose method:

```lua
{
    "(.*)/controllers/(.*).php",
    {
        { "[1]/models/[2:singularize].php",                       "Model",         true, 1},
        { "[1]/controllers/[2:pluralize].php",                    "Controller",    true, 2},
        { "[1]/models/[2:singularize,lower]/_config_form.yaml",   "Config Form",   true, 3},
        { "[1]/models/[2:singularize,lower]/_config_list.yaml",   "Config List",   true, 4},
        { "[1]/models/[2:singularize,lower]/_config_filter.yaml", "Config Filter", true, 5},
        { "[1]/controllers/[2:pluralize,lower]/*.*",              "Controller-F",  true, 6},
        { "[1]/models/[2:singularize,lower]/*.*",                 "Model-F",       true, 7},
    },
},

```